### PR TITLE
Remove IP address of 'None', which causes invalid replicas on down-scaling

### DIFF
--- a/templates/update_replicas.sh.j2
+++ b/templates/update_replicas.sh.j2
@@ -5,7 +5,8 @@ set +x
 # Fetch the latest list of private IP addresses for the LDAP ASG
 IP_ADDRESSES=$(aws ec2 describe-instances --output text --region {{ region }} \
                --query 'Reservations[*].Instances[*].[PrivateIpAddress]' \
-               --filters 'Name=tag:aws:autoscaling:groupName,Values={{ environment_name }}-ldap' | tr ' ' '\n' | sort -n)
+               --filters 'Name=tag:aws:autoscaling:groupName,Values={{ environment_name }}-ldap' \
+               | tr ' ' '\n' | grep -v 'None' | sort -n)
 
 # Check if any server ids have changed
 AWS_SERVER_IDS=$(echo "$IP_ADDRESSES" | awk '{print "olcServerID: " NR " ldap://" $s ":{{ ldap_port }}/"}')


### PR DESCRIPTION
Before fix, after terminating two nodes:
```
ldapsearch -Q -Y EXTERNAL -H ldapi:/// -l 1 -s base -b 'cn=config' 'olcServerID'

dn: cn=config
olcServerID: 1 ldap://None:389/
olcServerID: 2 ldap://None:389/
olcServerID: 3 ldap://10.160.37.85:389/
```

After fix:
```
ldapsearch -Q -Y EXTERNAL -H ldapi:/// -l 1 -s base -b 'cn=config' 'olcServerID'

dn: cn=config
olcServerID: 1 ldap://10.160.37.85:389/
```