### PR TITLE
Set equality index on entryCSN, as recommended in the LDAP admin guide.

### DIFF
--- a/templates/db.ldif.j2
+++ b/templates/db.ldif.j2
@@ -16,4 +16,5 @@ olcRootPW: {{ bind_password_hash.stdout }}
 olcTimeLimit: time.soft={{ query_time_limit }} time.hard={{ query_time_limit }}
 olcDbIndex: ou,cn,mail,surname,givenName eq,pres,sub
 olcDbIndex: objectClass,uniqueMember,uid,member,entryUUID eq,pres
+olcDbIndex: entryCSN eq
 olcDbMaxSize: {{ db_max_size }}

--- a/templates/overlays.ldif.j2
+++ b/templates/overlays.ldif.j2
@@ -43,3 +43,5 @@ changetype: add
 objectClass: olcOverlayConfig
 objectClass: olcSyncProvConfig
 olcOverlay: {3}syncprov
+# Write the contextCSN to disk every 100 operations or 10 minutes - whichever comes first
+olcSpCheckpoint: 100 10


### PR DESCRIPTION
https://www.openldap.org/doc/admin24/replication.html#Syncrepl%20Details
> On databases which support inequality indexing, setting an eq index on the entryCSN attribute and configuring contextCSN checkpoints will greatly speed up this scanning step.